### PR TITLE
Require the top library

### DIFF
--- a/script/console
+++ b/script/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "github/kv"
+require "github/ds"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.


### PR DESCRIPTION
This is me guessing, but I think with the rename (the last rename, and the really last rename) the console script didn't get updated to require the "github/ds" instead still requiring "github/kv" (which
also works).

This rewords that, the console still works (basically exactly the same as before) but it is slightly more correct.

So there, the world's most benign pull request.