### PR TITLE
Add and fix ruby 2.4.0 in travis builds, fixes #7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 2.2.7
   - 2.3.4
+  - 2.4.0
 before_script: gem install bundler -v 1.14.6
 script: bundle exec rake
 env:

--- a/github-ds.gemspec
+++ b/github-ds.gemspec
@@ -37,6 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "activerecord", "~> 5.0"
   spec.add_development_dependency "activesupport"
   spec.add_development_dependency "mysql2"
-  spec.add_development_dependency "activerecord-mysql-adapter"
   spec.add_development_dependency "mocha", "~> 1.2.1"
 end


### PR DESCRIPTION
Fixes #7 by removing the gems `activerecord-mysql-adapter` and –through it– `mysql`. The latter has not been updated since 2013 and has long been replaced by `mysql2`.

With these changes, all tests pass. 