### PR TITLE
Rails 5.1 CI/Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 /test/tmp/
+/db/

--- a/examples/example_setup.rb
+++ b/examples/example_setup.rb
@@ -10,16 +10,29 @@ attempts = 0
 begin
   ActiveRecord::Base.establish_connection({
     adapter: "mysql2",
+    username: "root",
     database: "github_ds_test",
   })
   ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS `key_values`")
-  require "generators/github/ds/templates/migration"
+
+  # remove db tree if present so we can start fresh
+  db_path = root_path.join("db")
+  db_path.rmtree if db_path.exist?
+
+  # use generator to create the migration
+  require "rails/generators"
+  require "generators/github/ds/active_record_generator"
+  Rails::Generators.invoke "github:ds:active_record"
+
+  # require migration and run it so we have the key values table
+  require db_path.join("migrate").children.first.to_s
   ActiveRecord::Migration.verbose = false
   CreateKeyValuesTable.up
 rescue
   raise if attempts >= 1
   ActiveRecord::Base.establish_connection({
     adapter: "mysql2",
+    username: "root",
   })
   ActiveRecord::Base.connection.execute("CREATE DATABASE `github_ds_test`")
   attempts += 1

--- a/examples/sql_with_connection.rb
+++ b/examples/sql_with_connection.rb
@@ -7,6 +7,7 @@ class SomeModel < ActiveRecord::Base
   establish_connection({
     adapter: "mysql2",
     database: "github_ds_test",
+    username: "root",
   })
 end
 

--- a/lib/generators/github/ds/active_record_generator.rb
+++ b/lib/generators/github/ds/active_record_generator.rb
@@ -1,5 +1,5 @@
 require "rails/generators/active_record"
-
+require "rails/version"
 module Github
   module Ds
     module Generators
@@ -10,11 +10,21 @@ module Github
         source_paths << File.join(File.dirname(__FILE__), "templates")
 
         def create_migration_file
-          migration_template "migration.rb", "db/migrate/create_key_values_table.rb"
+          migration_template "migration.rb", "db/migrate/create_key_values_table.rb", migration_version: migration_version
         end
 
         def self.next_migration_number(dirname)
           ::ActiveRecord::Generators::Base.next_migration_number(dirname)
+        end
+
+        def self.migration_version
+          if Rails.version.start_with?('5')
+            "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]"
+          end
+        end
+
+        def migration_version
+          self.class.migration_version
         end
       end
     end

--- a/lib/generators/github/ds/templates/migration.rb
+++ b/lib/generators/github/ds/templates/migration.rb
@@ -1,4 +1,4 @@
-class CreateKeyValuesTable < ActiveRecord::Migration
+class CreateKeyValuesTable < ActiveRecord::Migration<%= migration_version %>
   def self.up
     create_table :key_values do |t|
       t.string :key, :null => false

--- a/test/generators/github/store/active_record_generator_test.rb
+++ b/test/generators/github/store/active_record_generator_test.rb
@@ -5,15 +5,20 @@ require "active_record"
 require "rails/generators/test_case"
 require "generators/github/ds/active_record_generator"
 
-class GithubKVActiveRecordGeneratorTest < Rails::Generators::TestCase
-  tests Github::DS::Generators::ActiveRecordGenerator
+class GithubDSActiveRecordGeneratorTest < Rails::Generators::TestCase
+  tests Github::Ds::Generators::ActiveRecordGenerator
   destination File.expand_path("../../../../tmp", __FILE__)
   setup :prepare_destination
 
   def test_generates_migration
     run_generator
+    migration_version = if Rails::VERSION::MAJOR.to_i < 5
+      ""
+    else
+      "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]"
+    end
     assert_migration "db/migrate/create_key_values_table.rb", <<-EOM
-class CreateKeyValuesTable < ActiveRecord::Migration
+class CreateKeyValuesTable < ActiveRecord::Migration#{migration_version}
   def self.up
     create_table :key_values do |t|
       t.string :key, :null => false

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,7 @@ attempts = 0
 begin
   ActiveRecord::Base.establish_connection({
     adapter: "mysql2",
+    username: "root",
     database: "github_ds_test",
   })
   ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS `key_values`")
@@ -20,6 +21,7 @@ rescue
   raise if attempts >= 1
   ActiveRecord::Base.establish_connection({
     adapter: "mysql2",
+    username: "root",
   })
   ActiveRecord::Base.connection.execute("CREATE DATABASE `github_ds_test`")
   attempts += 1

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,7 @@
 require "bundler/setup"
-$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+require "pathname"
+root_path = Pathname(File.expand_path("../..", __FILE__))
+$LOAD_PATH.unshift root_path.join("lib").to_s
 require "github/kv"
 
 require "timecop"
@@ -14,7 +16,18 @@ begin
     database: "github_ds_test",
   })
   ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS `key_values`")
-  require "generators/github/ds/templates/migration"
+
+  # remove db tree if present so we can start fresh
+  db_path = root_path.join("db")
+  db_path.rmtree if db_path.exist?
+
+  # use generator to create the migration
+  require "rails/generators"
+  require "generators/github/ds/active_record_generator"
+  Rails::Generators.invoke "github:ds:active_record"
+
+  # require migration and run it so we have the key values table
+  require db_path.join("migrate").children.first.to_s
   ActiveRecord::Migration.verbose = false
   CreateKeyValuesTable.up
 rescue


### PR DESCRIPTION
Rails 5.1 was failing CI due to migrations now requiring a version. This adds the version to Rails version 5.x similar to how devise does it ([template](https://github.com/plataformatec/devise/blob/079ed3b6f8b671acde2dd630d28d21adb010fb3a/lib/generators/active_record/templates/migration.rb#L1), [generator](https://github.com/plataformatec/devise/blob/079ed3b6f8b671acde2dd630d28d21adb010fb3a/lib/generators/active_record/devise_generator.rb#L16)), [migration version](https://github.com/plataformatec/devise/blob/079ed3b6f8b671acde2dd630d28d21adb010fb3a/lib/generators/active_record/devise_generator.rb#L90-L94).

The downside is the migration file was being used in tests and examples (to avoid repeating myself) and now it can't be as easily (due to including erb). Now instead it uses the included generator to generate a migration file which is then required and run. Doesn't feel great, but it works and does add a bit more coverage to the generator since tests/examples won't work if it doesn't work anymore.

Also needed to add a username to the mysql connections so I went with root. We can make the flexible for people who dev without root, if necessary.