### PR TITLE
Make initialize without block return `true` for `ok?`

### DIFF
--- a/lib/github/result.rb
+++ b/lib/github/result.rb
@@ -15,7 +15,7 @@ module GitHub
     #
     def initialize
       begin
-        @value = yield
+        @value = yield if block_given?
         @error = nil
       rescue => e
         @error = e

--- a/test/github/result_test.rb
+++ b/test/github/result_test.rb
@@ -83,4 +83,8 @@ class GitHub::ResultTest < Minitest::Test
 
     assert_equal e, GitHub::Result.new { raise e }.error
   end
+
+  def test_initialize_without_block
+    assert_predicate GitHub::Result.new, :ok?
+  end
 end


### PR DESCRIPTION
It was returning false because the lack of a block would yield a local jump error which would then be rescued setting error and thus ok? to false.


Without the `if block_given?` check:

```
Failure:
GitHub::ResultTest#test_initialize_without_block [/Users/jnunemaker/github/github-ds/test/github/result_test.rb:88]:
Expected #<GitHub::Result:0x3fc6ca9bea80 error: #<LocalJumpError: no block given (yield)>> to be ok?.
```

With check the tests pass.