### PR TITLE
Adds support for binary values in `GitHub::KV`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.2.2
+
+Additions
+
+* `GitHub::KV` accepts `SQL::Literal` as valid values https://github.com/github/github-ds/pull/21/commits/c11d4e3154dd3435d509a3356f46d0a2981d7234
+
+Fixes
+
+* Value length validation takes into account that strings can be made of multi-byte characters https://github.com/github/github-ds/pull/21/commits/5156f95ef04b1ecf2ce90929c5752b2e61d39566
+
 ## 0.2.1
 
 Additions

--- a/lib/github/ds/version.rb
+++ b/lib/github/ds/version.rb
@@ -1,5 +1,5 @@
 module GitHub
   module DS
-    VERSION = "0.2.1"
+    VERSION = "0.2.2"
   end
 end

--- a/lib/github/kv.rb
+++ b/lib/github/kv.rb
@@ -271,14 +271,18 @@ module GitHub
     end
 
   private
-    def validate_key(key)
-      raise TypeError, "key must be a String in #{self.class.name}, but was #{key.class}" unless key.is_a?(String)
+    def validate_key(key, error_message: nil)
+      unless key.is_a?(String)
+        raise TypeError, error_message || "key must be a String in #{self.class.name}, but was #{key.class}"
+      end
 
       validate_key_length(key)
     end
 
-    def validate_value(value)
-      raise TypeError, "value must be a String in #{self.class.name}, but was #{value.class}" unless value.is_a?(String)
+    def validate_value(value, error_message: nil)
+      unless value.is_a?(String) || value.is_a?(GitHub::SQL::Literal)
+        raise TypeError, error_message || "value must be a String in #{self.class.name} or SQL::Literal, but was #{value.class}"
+      end
 
       validate_value_length(value)
     end
@@ -299,20 +303,12 @@ module GitHub
 
     def validate_key_value_hash(kvs)
       unless kvs.is_a?(Hash)
-        raise TypeError, "kvs must be a {String => String} in #{self.class.name}, but was #{key.class}"
+        raise TypeError, "kvs must be a {String => String} in #{self.class.name}, but was #{kvs.class}"
       end
 
       kvs.each do |key, value|
-        unless key.is_a?(String)
-          raise TypeError, "kvs must be a {String => String} in #{self.class.name}, but also saw at least one key of type #{key.class}"
-        end
-
-        unless value.is_a?(String)
-          raise TypeError, "kvs must be a {String => String} in #{self.class.name}, but also saw at least one value of type #{value.class}"
-        end
-
-        validate_key_length(key)
-        validate_value_length(value)
+        validate_key(key, error_message: "kvs must be a {String => [String|Literal]} in #{self.class.name}, but also saw at least one key of type #{key.class}")
+        validate_value(value, error_message: "kvs must be a {String => [String|Literal]} in #{self.class.name}, but also saw at least one value of type #{value.class}")
       end
     end
 

--- a/lib/github/kv.rb
+++ b/lib/github/kv.rb
@@ -319,7 +319,7 @@ module GitHub
     end
 
     def validate_value_length(value)
-      if value.length > MAX_VALUE_LENGTH
+      if value.bytesize > MAX_VALUE_LENGTH
         raise ValueLengthError, "value of length #{value.length} exceeds maximum value length of #{MAX_VALUE_LENGTH}"
       end
     end

--- a/lib/github/kv.rb
+++ b/lib/github/kv.rb
@@ -307,8 +307,8 @@ module GitHub
       end
 
       kvs.each do |key, value|
-        validate_key(key, error_message: "kvs must be a {String => [String|Literal]} in #{self.class.name}, but also saw at least one key of type #{key.class}")
-        validate_value(value, error_message: "kvs must be a {String => [String|Literal]} in #{self.class.name}, but also saw at least one value of type #{value.class}")
+        validate_key(key, error_message: "kvs must be a {String => [String | SQL::Literal]} in #{self.class.name}, but also saw at least one key of type #{key.class}")
+        validate_value(value, error_message: "kvs must be a {String => [String | SQL::Literal]} in #{self.class.name}, but also saw at least one value of type #{value.class}")
       end
     end
 

--- a/lib/github/sql.rb
+++ b/lib/github/sql.rb
@@ -44,6 +44,10 @@ module GitHub
       def inspect
         "<#{self.class.name} #{value}>"
       end
+
+      def bytesize
+        value.bytesize
+      end
     end
 
     # Internal: a list of arrays of values for insertion into SQL.

--- a/test/github/kv_test.rb
+++ b/test/github/kv_test.rb
@@ -188,5 +188,9 @@ class GitHub::KVTest < Minitest::Test
     assert_raises GitHub::KV::ValueLengthError do
       @kv.set("foo", "A" * 65536)
     end
+
+    assert_raises GitHub::KV::ValueLengthError do
+      @kv.set("foo", "💥" * 20000)
+    end
   end
 end

--- a/test/github/kv_test.rb
+++ b/test/github/kv_test.rb
@@ -21,6 +21,14 @@ class GitHub::KVTest < Minitest::Test
     assert_equal "bar", @kv.get("foo").value!
   end
 
+  def test_get_set_binary_data
+    assert_nil @kv.get("foo").value!
+
+    @kv.set("foo", GitHub::SQL::BINARY("bar"))
+
+    assert_equal "bar", @kv.get("foo").value!
+  end
+
   def test_mget_and_mset
     assert_equal [nil, nil], @kv.mget(["a", "b"]).value!
 


### PR DESCRIPTION
This PR:

- Extends `GitHub::KV` to allow `SQL::Literal` values, this can be used to cast as binary literals `utf8mb4` strings, that otherwise would rise a warning in MySQL. A usage example wil could be 

    ```ruby
    kv.set("key", SQL::BINARY( "🍻"))
    ```

- Fixes `GitHub::KV` to take into account that strings values can be of composed of multi-byte characters.
- Fixes the of error message in `validate_key_value_hash`

cc @jnunemaker @github/platform-data