### PR TITLE
Scope `ensures` to only run if default_timezone actually altered

### DIFF
--- a/lib/github/sql.rb
+++ b/lib/github/sql.rb
@@ -167,16 +167,18 @@ module GitHub
 
       query << " " unless query.empty?
 
-      if @force_tz
-        zone = ActiveRecord::Base.default_timezone
-        ActiveRecord::Base.default_timezone = @force_tz
+      begin
+        if @force_tz
+          zone = ActiveRecord::Base.default_timezone
+          ActiveRecord::Base.default_timezone = @force_tz
+        end
+
+        query << interpolate(sql.strip, extras)
+
+        self
+      ensure
+        ActiveRecord::Base.default_timezone = zone if @force_tz
       end
-
-      query << interpolate(sql.strip, extras)
-
-      self
-    ensure
-      ActiveRecord::Base.default_timezone = zone if @force_tz
     end
 
     # Public: Add a chunk of SQL to the query, unless query generated so far is empty.

--- a/test/github/sql_test.rb
+++ b/test/github/sql_test.rb
@@ -213,4 +213,27 @@ class GitHub::SQLTest < Minitest::Test
       ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS `repositories`")
     end
   end
+
+  def test_add_doesnt_modify_timezone_if_early_return_invoked
+    begin
+      original_default_timezone = ActiveRecord::Base.default_timezone
+      refute_nil original_default_timezone
+
+      ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS `repositories`")
+      ActiveRecord::Base.connection.execute <<-SQL
+        CREATE TABLE `repositories` (
+          `id` int(11) NOT NULL AUTO_INCREMENT,
+          `name` varchar(255) DEFAULT NULL,
+          PRIMARY KEY (`id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+      SQL
+
+      sql = GitHub::SQL.new("SELECT * FROM repositories WHERE id = ?", force_timezone: :local)
+      sql.add nil, id: 1
+
+      assert_equal original_default_timezone, ActiveRecord::Base.default_timezone
+    ensure
+      ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS `repositories`")
+    end
+  end
 end


### PR DESCRIPTION
This is a particularly subtle and hard to catch bug. `ensure` when used at the method definition level runs on every method call regardless of on early return. This means that when using `:force_timezone` and calling `results` more than once, the default_timezone was getting set to nil, because the second invocation would early return, not set the `zone` variable and thus set default_timezone to nil in the ensure block.