### PR TITLE
v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.2.3
+
+Additions
+
+* github-ds does not use `blank?` anymore hence not depending on `active_support/core_ext/object/blank` https://github.com/github/github-ds/commit/a22c397eaaa00bb441fb4a0ecdf3e371daa9001a
+
+Fixes
+
+* `ActiveRecord::Base.default_timezone` is not unintentionally set to `nil` https://github.com/github/github-ds/pull/22
+
 ## 0.2.2
 
 Additions

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Nothing currently on our radar other than continued maintenance. Have a big idea
 |---|---|
 | ![@charliesome](https://avatars3.githubusercontent.com/u/179065?s=64) | [@charliesome](https://github.com/charliesome) |
 | ![@jnunemaker](https://avatars3.githubusercontent.com/u/235?s=64) | [@jnunemaker](https://github.com/jnunemaker) |
+| ![@miguelff](https://avatars3.githubusercontent.com/u/210307?s=64) | [@miguelff](https://github.com/miguelff) |
 | ![@zerowidth](https://avatars3.githubusercontent.com/u/3999?s=64) | [@zerowidth](https://github.com/zerowidth) |
 
 ## License

--- a/lib/github/ds/version.rb
+++ b/lib/github/ds/version.rb
@@ -1,5 +1,5 @@
 module GitHub
   module DS
-    VERSION = "0.2.2"
+    VERSION = "0.2.3"
   end
 end

--- a/lib/github/sql.rb
+++ b/lib/github/sql.rb
@@ -149,7 +149,7 @@ module GitHub
       @connection = @binds.delete :connection
       @force_tz   = @binds.delete :force_timezone
 
-      add query if !query.nil?
+      add query
     end
 
     # Public: Add a chunk of SQL to the query. Any ":keyword" tokens in the SQL
@@ -163,7 +163,7 @@ module GitHub
     # Returns self.
     # Raises GitHub::SQL::BadBind for unknown keyword tokens.
     def add(sql, extras = nil)
-      return self if sql.blank?
+      return self if sql.nil? || sql.empty?
 
       query << " " unless query.empty?
 


### PR DESCRIPTION
This PR bumps `VERSION` to `0.2.3` after removing the dependency `github-ds`  had on `active_suport/core-ext/object/blank`

It also adds me to the list of maintainers.