### PR TITLE
Adds `SQL.transaction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
+## 0.2.4
+
+Additions
+
+* `GitHub::SQL.transaction` was added to allow `GitHub::SQL` queries to run transactionally https://github.com/github/github-ds/pull/24
+
 ## 0.2.3
 
 Additions
 
-* github-ds does not use `blank?` anymore hence not depending on `active_support/core_ext/object/blank` https://github.com/github/github-ds/commit/a22c397eaaa00bb441fb4a0ecdf3e371daa9001a
+* github-ds does not use `blank?` anymore, thus not depending on `active_support/core_ext/object/blank` https://github.com/github/github-ds/commit/a22c397eaaa00bb441fb4a0ecdf3e371daa9001a
 
 Fixes
 

--- a/lib/github/ds/version.rb
+++ b/lib/github/ds/version.rb
@@ -1,5 +1,5 @@
 module GitHub
   module DS
-    VERSION = "0.2.3"
+    VERSION = "0.2.4"
   end
 end

--- a/lib/github/sql.rb
+++ b/lib/github/sql.rb
@@ -67,6 +67,13 @@ module GitHub
       end
     end
 
+    # Public: Run inside a transaction
+    def self.transaction
+      ActiveRecord::Base.connection.transaction do
+        yield
+      end
+    end
+
     # Public: Instantiate a literal SQL value.
     #
     # WARNING: The given value is LITERALLY inserted into your SQL without being


### PR DESCRIPTION
To add support for running queries inside an
`ActiveRecord::Base.transaction` scope.