### PR TITLE
Replace absolute `require` statements in favor of `require_relative`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.2.5
+
+Fixes
+
+* Replaces `requires` with `require_relative` to avoid requirement errors
+when the gem is required inside the a "gihub" load path https://github.com/github/github-ds/commit/cb50e5318c911cf5bbf30fd07ca8ea93bfbf1c6d
+
 ## 0.2.4
 
 Additions

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Once you have created and executed the migration, KV can do neat things like thi
 
 ```ruby
 require "pp"
-require "github/kv"
 
 # Create new instance using ActiveRecord's default connection.
 kv = GitHub::KV.new { ActiveRecord::Base.connection }

--- a/lib/github/ds.rb
+++ b/lib/github/ds.rb
@@ -1,8 +1,8 @@
-require "github/ds/version"
+require_relative "ds/version"
 
 module GitHub
   module DS
   end
 end
 
-require "github/kv"
+require_relative "kv"

--- a/lib/github/ds/version.rb
+++ b/lib/github/ds/version.rb
@@ -1,5 +1,5 @@
 module GitHub
   module DS
-    VERSION = "0.2.4"
+    VERSION = "0.2.5"
   end
 end

--- a/lib/github/kv.rb
+++ b/lib/github/kv.rb
@@ -1,5 +1,5 @@
-require "github/result"
-require "github/sql"
+require_relative "result"
+require_relative "sql"
 
 # GitHub::KV is a key/value data store backed by MySQL (however, the backing
 # store used should be regarded as an implementation detail).


### PR DESCRIPTION
This PR replaces `require` with `require_relative` to avoid requirement errors when the gem is required inside the a "gihub" load path in a rails application.

cc @jnunemaker @github/platform-data 

