### PR TITLE
Ensure @hash_results is an array on rails 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.7
+
+Fixes
+
+* `GitHub::SQL#hash_results` now correctly returns an array of hashes on Rails 4+ rather than `ActiveRecord::Result`
+
 ## 0.2.6
 
 Fixes

--- a/lib/github/ds/version.rb
+++ b/lib/github/ds/version.rb
@@ -1,5 +1,5 @@
 module GitHub
   module DS
-    VERSION = "0.2.6"
+    VERSION = "0.2.7"
   end
 end

--- a/lib/github/sql.rb
+++ b/lib/github/sql.rb
@@ -297,7 +297,7 @@ module GitHub
 
         when /\ASELECT/i
           # Why not execute or select_rows? Because select_all hits the query cache.
-          @hash_results = connection.select_all(query, "#{self.class.name} Select")
+          @hash_results = connection.select_all(query, "#{self.class.name} Select").to_ary
           @results = @hash_results.map(&:values)
 
         else


### PR DESCRIPTION
Rails 4 changes the return type of `select_all` from `Array` to `ActiveRecord::Result`.

Calling `to_ary` on the `ActiveRecord::Result` returns the underlying array without having to make a copy. Calling `to_ary` on an `Array` (as would be the case on Rails 3.2) just returns the original array.

cc @jnunemaker @github/rails-upgrades 