### PR TITLE
Move Time Zone Forcing to sanitize

### DIFF
--- a/lib/github/sql.rb
+++ b/lib/github/sql.rb
@@ -447,6 +447,7 @@ module GitHub
 
     private
 
+    # Private: Forces ActiveRecord's default timezone for duration of block.
     def enforce_timezone(&block)
       begin
         if @force_tz

--- a/lib/github/sql.rb
+++ b/lib/github/sql.rb
@@ -151,10 +151,10 @@ module GitHub
 
       @last_insert_id = nil
       @affected_rows  = nil
-      @binds      = binds ? binds.dup : {}
-      @query      = ""
-      @connection = @binds.delete :connection
-      @force_tz   = @binds.delete :force_timezone
+      @binds          = binds ? binds.dup : {}
+      @query          = ""
+      @connection     = @binds.delete :connection
+      @force_timezone = @binds.delete :force_timezone
 
       add query
     end
@@ -449,14 +449,14 @@ module GitHub
     # Private: Forces ActiveRecord's default timezone for duration of block.
     def enforce_timezone(&block)
       begin
-        if @force_tz
+        if @force_timezone
           zone = ActiveRecord::Base.default_timezone
-          ActiveRecord::Base.default_timezone = @force_tz
+          ActiveRecord::Base.default_timezone = @force_timezone
         end
 
         yield if block_given?
       ensure
-        ActiveRecord::Base.default_timezone = zone if @force_tz
+        ActiveRecord::Base.default_timezone = zone if @force_timezone
       end
     end
   end

--- a/lib/github/sql.rb
+++ b/lib/github/sql.rb
@@ -173,10 +173,7 @@ module GitHub
       return self if sql.nil? || sql.empty?
 
       query << " " unless query.empty?
-
-      enforce_timezone do
-        query << interpolate(sql.strip, extras)
-      end
+      query << interpolate(sql.strip, extras)
 
       self
     end
@@ -412,7 +409,9 @@ module GitHub
         connection.quote value.name
 
       when DateTime, Time, Date
-        connection.quote value.to_s(:db)
+        enforce_timezone do
+          connection.quote value.to_s(:db)
+        end
 
       when true
         connection.quoted_true

--- a/test/github/sql_test.rb
+++ b/test/github/sql_test.rb
@@ -156,7 +156,7 @@ class GitHub::SQLTest < Minitest::Test
         GitHub::SQL.run("INSERT INTO affected_rows_test VALUES (3), (4)")
         raise "BOOM"
       end
-    rescue => e
+    rescue
       assert_equal 0, GitHub::SQL.new("Select count(*) from affected_rows_test").value
     else
       fail

--- a/test/github/sql_test.rb
+++ b/test/github/sql_test.rb
@@ -35,7 +35,7 @@ class GitHub::SQLTest < Minitest::Test
   def test_sanitize
     SANITIZE_TESTS.each do |input, expected|
       assert_equal expected, GitHub::SQL.new.sanitize(input),
-      "#{input.inspect} sanitizes as #{expected.inspect}"
+        "#{input.inspect} sanitizes as #{expected.inspect}"
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 require "bundler/setup"
+require "pp"
 require "pathname"
 root_path = Pathname(File.expand_path("../..", __FILE__))
 $LOAD_PATH.unshift root_path.join("lib").to_s


### PR DESCRIPTION
This does a few minor things:

* encapsulates enforcing ActiveRecord.default_timezone into a single method
* moves usage of this method from `add` to `sanitize` (which is used by `interpolate` which is used by `add`). This is mostly a localization of the usage to where it is needed rather than the higher level spot around add. Should behave identical and makes it so `interpolate` can be used without worrying about timezone stuff being wrong.
* renames @forze_tz to @force_timezone which matches the hash option and is more descriptive.