### PR TITLE
Minor Tidying

### DIFF
--- a/lib/github/sql.rb
+++ b/lib/github/sql.rb
@@ -210,41 +210,6 @@ module GitHub
       self
     end
 
-    # Internal: The object we use to execute SQL and retrieve results. Defaults
-    # to AR::B.connection, but can be overridden with a ":connection" key when
-    # initializing a new instance.
-    def connection
-      @connection || ActiveRecord::Base.connection
-    end
-
-    # Public: The number of affected rows for this connection.
-    def affected_rows
-      @affected_rows || connection.raw_connection.affected_rows
-    end
-
-    # Public: the number of rows found by the query.
-    #
-    # Returns FOUND_ROWS() if a SELECT query included SQL_CALC_FOUND_ROWS.
-    # Raises if SQL_CALC_FOUND_ROWS was not present in the query.
-    def found_rows
-      raise "no SQL_CALC_FOUND_ROWS clause present" unless defined? @found_rows
-      @found_rows
-    end
-
-    # Internal: when a SQL_CALC_FOUND_ROWS clause is present in a SELECT query,
-    # retrieve the FOUND_ROWS() value to get a count of the rows sans any
-    # LIMIT/OFFSET clause.
-    def retrieve_found_row_count
-      if query =~ /\A\s*SELECT\s+SQL_CALC_FOUND_ROWS\s+/i
-        @found_rows = connection.select_value "SELECT FOUND_ROWS()", self.class.name
-      end
-    end
-
-    # Public: The last inserted ID for this connection.
-    def last_insert_id
-      @last_insert_id || connection.raw_connection.last_insert_id
-    end
-
     # Public: Map each row to an instance of an ActiveRecord::Base subclass.
     def models(klass)
       return @models if defined? @models
@@ -342,6 +307,41 @@ module GitHub
     # Returns an Array or nil.
     def values
       results.map(&:first)
+    end
+
+    # Internal: The object we use to execute SQL and retrieve results. Defaults
+    # to AR::B.connection, but can be overridden with a ":connection" key when
+    # initializing a new instance.
+    def connection
+      @connection || ActiveRecord::Base.connection
+    end
+
+    # Public: The number of affected rows for this connection.
+    def affected_rows
+      @affected_rows || connection.raw_connection.affected_rows
+    end
+
+    # Public: the number of rows found by the query.
+    #
+    # Returns FOUND_ROWS() if a SELECT query included SQL_CALC_FOUND_ROWS.
+    # Raises if SQL_CALC_FOUND_ROWS was not present in the query.
+    def found_rows
+      raise "no SQL_CALC_FOUND_ROWS clause present" unless defined? @found_rows
+      @found_rows
+    end
+
+    # Internal: when a SQL_CALC_FOUND_ROWS clause is present in a SELECT query,
+    # retrieve the FOUND_ROWS() value to get a count of the rows sans any
+    # LIMIT/OFFSET clause.
+    def retrieve_found_row_count
+      if query =~ /\A\s*SELECT\s+SQL_CALC_FOUND_ROWS\s+/i
+        @found_rows = connection.select_value "SELECT FOUND_ROWS()", self.class.name
+      end
+    end
+
+    # Public: The last inserted ID for this connection.
+    def last_insert_id
+      @last_insert_id || connection.raw_connection.last_insert_id
     end
 
     # Internal: Replace ":keywords" with sanitized values from binds or extras.

--- a/lib/github/sql.rb
+++ b/lib/github/sql.rb
@@ -302,17 +302,6 @@ module GitHub
       end
     end
 
-    # Public: If the query is a SELECT, return an array of hashes instead of an array of arrays.
-    def hash_results
-      results
-      @hash_results || @results
-    end
-
-    # Public: Get first row of results.
-    def row
-      results.first
-    end
-
     # Public: Execute, ignoring results. This is useful when the results of a
     # query aren't important, often INSERTs, UPDATEs, or DELETEs.
     #
@@ -325,6 +314,17 @@ module GitHub
       results
 
       self
+    end
+
+    # Public: If the query is a SELECT, return an array of hashes instead of an array of arrays.
+    def hash_results
+      results
+      @hash_results || @results
+    end
+
+    # Public: Get first row of results.
+    def row
+      results.first
     end
 
     # Public: Get the first column of the first row of results.

--- a/lib/github/sql.rb
+++ b/lib/github/sql.rb
@@ -287,23 +287,6 @@ module GitHub
       @found_rows
     end
 
-    # Internal: Replace ":keywords" with sanitized values from binds or extras.
-    def interpolate(sql, extras = nil)
-      sql.gsub(/:[a-z][a-z0-9_]*/) do |raw|
-        sym = raw[1..-1].intern # O.o gensym
-
-        if extras && extras.include?(sym)
-          val = extras[sym]
-        elsif binds.include?(sym)
-          val = binds[sym]
-        end
-
-        raise BadBind.new raw if val.nil?
-
-        sanitize val
-      end
-    end
-
     # Public: The last inserted ID for this connection.
     def last_insert_id
       @last_insert_id || connection.raw_connection.last_insert_id
@@ -400,6 +383,40 @@ module GitHub
       end
     end
 
+    # Public: Get the first column of the first row of results.
+    def value
+      row && row.first
+    end
+
+    # Public: Is there a value?
+    def value?
+      !value.nil?
+    end
+
+    # Public: Get first column of every row of results.
+    #
+    # Returns an Array or nil.
+    def values
+      results.map(&:first)
+    end
+
+    # Internal: Replace ":keywords" with sanitized values from binds or extras.
+    def interpolate(sql, extras = nil)
+      sql.gsub(/:[a-z][a-z0-9_]*/) do |raw|
+        sym = raw[1..-1].intern # O.o gensym
+
+        if extras && extras.include?(sym)
+          val = extras[sym]
+        elsif binds.include?(sym)
+          val = binds[sym]
+        end
+
+        raise BadBind.new raw if val.nil?
+
+        sanitize val
+      end
+    end
+
     # Internal: Make `value` database-safe. Ish.
     def sanitize(value)
       case value
@@ -440,23 +457,6 @@ module GitHub
       else
         raise BadValue, value
       end
-    end
-
-    # Public: Get the first column of the first row of results.
-    def value
-      row && row.first
-    end
-
-    # Public: Is there a value?
-    def value?
-      !value.nil?
-    end
-
-    # Public: Get first column of every row of results.
-    #
-    # Returns an Array or nil.
-    def values
-      results.map(&:first)
     end
   end
 end

--- a/lib/github/sql.rb
+++ b/lib/github/sql.rb
@@ -199,11 +199,6 @@ module GitHub
       add sql, extras
     end
 
-    # Public: The number of affected rows for this connection.
-    def affected_rows
-      @affected_rows || connection.raw_connection.affected_rows
-    end
-
     # Public: Add additional bind values to be interpolated each time SQL
     # is added to the query.
     #
@@ -220,6 +215,11 @@ module GitHub
     # initializing a new instance.
     def connection
       @connection || ActiveRecord::Base.connection
+    end
+
+    # Public: The number of affected rows for this connection.
+    def affected_rows
+      @affected_rows || connection.raw_connection.affected_rows
     end
 
     # Public: the number of rows found by the query.

--- a/lib/github/sql.rb
+++ b/lib/github/sql.rb
@@ -34,11 +34,12 @@ module GitHub
   #   GitHub::SQL::ROWS(array_of_arrays).
   #
   class SQL
-    # Public: Run inside a transaction
-    def self.transaction
-      ActiveRecord::Base.connection.transaction do
-        yield
-      end
+    # Public: Run inside a transaction. Class version of this method only works
+    # if only one connection is in use. If passing connections to
+    # GitHub::SQL#initialize or overriding connection then you'll need to use
+    # the instance version.
+    def self.transaction(options = {}, &block)
+      ActiveRecord::Base.connection.transaction(options, &block)
     end
 
     # Public: Instantiate a literal SQL value.
@@ -307,6 +308,11 @@ module GitHub
     # Returns an Array or nil.
     def values
       results.map(&:first)
+    end
+
+    # Public: Run inside a transaction for the connection.
+    def transaction(options = {}, &block)
+      connection.transaction(options, &block)
     end
 
     # Internal: The object we use to execute SQL and retrieve results. Defaults

--- a/lib/github/sql.rb
+++ b/lib/github/sql.rb
@@ -103,6 +103,57 @@ module GitHub
       Rows.new(rows)
     end
 
+    # Public: Create and execute a new SQL query, ignoring results.
+    #
+    # sql      - A SQL string. See GitHub::SQL#add for details.
+    # bindings - Optional bind values. See GitHub::SQL#add for details.
+    #
+    # Returns self.
+    def self.run(sql, bindings = {})
+      new(sql, bindings).run
+    end
+
+    # Public: Create and execute a new SQL query, returning its hash_result rows.
+    #
+    # sql      - A SQL string. See GitHub::SQL#add for details.
+    # bindings - Optional bind values. See GitHub::SQL#add for details.
+    #
+    # Returns an Array of result hashes.
+    def self.hash_results(sql, bindings = {})
+      new(sql, bindings).hash_results
+    end
+
+    # Public: Create and execute a new SQL query, returning its result rows.
+    #
+    # sql      - A SQL string. See GitHub::SQL#add for details.
+    # bindings - Optional bind values. See GitHub::SQL#add for details.
+    #
+    # Returns an Array of result arrays.
+    def self.results(sql, bindings = {})
+      new(sql, bindings).results
+    end
+
+    # Public: Create and execute a new SQL query, returning the value of the
+    # first column of the first result row.
+    #
+    # sql      - A SQL string. See GitHub::SQL#add for details.
+    # bindings - Optional bind values. See GitHub::SQL#add for details.
+    #
+    # Returns a value or nil.
+    def self.value(sql, bindings = {})
+      new(sql, bindings).value
+    end
+
+    # Public: Create and execute a new SQL query, returning its values.
+    #
+    # sql      - A SQL string. See GitHub::SQL#add for details.
+    # bindings - Optional bind values. See GitHub::SQL#add for details.
+    #
+    # Returns an Array of values.
+    def self.values(sql, bindings = {})
+      new(sql, bindings).values
+    end
+
     # Public: prepackaged literal values.
     NULL = Literal.new "NULL"
     NOW  = Literal.new "NOW()"
@@ -347,57 +398,6 @@ module GitHub
       if query =~ /\A\s*SELECT\s+SQL_CALC_FOUND_ROWS\s+/i
         @found_rows = connection.select_value "SELECT FOUND_ROWS()", self.class.name
       end
-    end
-
-    # Public: Create and execute a new SQL query, ignoring results.
-    #
-    # sql      - A SQL string. See GitHub::SQL#add for details.
-    # bindings - Optional bind values. See GitHub::SQL#add for details.
-    #
-    # Returns self.
-    def self.run(sql, bindings = {})
-      new(sql, bindings).run
-    end
-
-    # Public: Create and execute a new SQL query, returning its hash_result rows.
-    #
-    # sql      - A SQL string. See GitHub::SQL#add for details.
-    # bindings - Optional bind values. See GitHub::SQL#add for details.
-    #
-    # Returns an Array of result hashes.
-    def self.hash_results(sql, bindings = {})
-      new(sql, bindings).hash_results
-    end
-
-    # Public: Create and execute a new SQL query, returning its result rows.
-    #
-    # sql      - A SQL string. See GitHub::SQL#add for details.
-    # bindings - Optional bind values. See GitHub::SQL#add for details.
-    #
-    # Returns an Array of result arrays.
-    def self.results(sql, bindings = {})
-      new(sql, bindings).results
-    end
-
-    # Public: Create and execute a new SQL query, returning the value of the
-    # first column of the first result row.
-    #
-    # sql      - A SQL string. See GitHub::SQL#add for details.
-    # bindings - Optional bind values. See GitHub::SQL#add for details.
-    #
-    # Returns a value or nil.
-    def self.value(sql, bindings = {})
-      new(sql, bindings).value
-    end
-
-    # Public: Create and execute a new SQL query, returning its values.
-    #
-    # sql      - A SQL string. See GitHub::SQL#add for details.
-    # bindings - Optional bind values. See GitHub::SQL#add for details.
-    #
-    # Returns an Array of values.
-    def self.values(sql, bindings = {})
-      new(sql, bindings).values
     end
 
     # Internal: Make `value` database-safe. Ish.

--- a/lib/github/sql/errors.rb
+++ b/lib/github/sql/errors.rb
@@ -1,0 +1,22 @@
+module GitHub
+  class SQL
+    # Public: A superclass for errors.
+    class Error < RuntimeError
+    end
+
+    # Public: Raised when a bound ":keyword" value isn't available.
+    class BadBind < Error
+      def initialize(keyword)
+        super "There's no bind value for #{keyword.inspect}"
+      end
+    end
+
+    # Public: Raised when a bound value can't be sanitized.
+    class BadValue < Error
+      def initialize(value, description = nil)
+        description ||= "a #{value.class.name}"
+        super "Can't sanitize #{description}: #{value.inspect}"
+      end
+    end
+  end
+end

--- a/lib/github/sql/literal.rb
+++ b/lib/github/sql/literal.rb
@@ -1,0 +1,25 @@
+module GitHub
+  class SQL
+    # Internal: a SQL literal value.
+    class Literal
+      # Public: the string value of this literal
+      attr_reader :value
+
+      def initialize(value)
+        @value = value.to_s.dup.freeze
+      end
+
+      def inspect
+        "<#{self.class.name} #{value}>"
+      end
+
+      def bytesize
+        value.bytesize
+      end
+    end
+
+    # Public: prepackaged literal values.
+    NULL = Literal.new "NULL"
+    NOW  = Literal.new "NOW()"
+  end
+end

--- a/lib/github/sql/rows.rb
+++ b/lib/github/sql/rows.rb
@@ -1,0 +1,20 @@
+module GitHub
+  class SQL
+    # Internal: a list of arrays of values for insertion into SQL.
+    class Rows
+      # Public: the Array of row values
+      attr_reader :values
+
+      def initialize(values)
+        unless values.all? { |v| v.is_a? Array }
+          raise ArgumentError, "cannot instantiate SQL rows with anything but arrays"
+        end
+        @values = values.dup.freeze
+      end
+
+      def inspect
+        "<#{self.class.name} #{values.inspect}>"
+      end
+    end
+  end
+end

--- a/test/github/sql_test.rb
+++ b/test/github/sql_test.rb
@@ -147,7 +147,7 @@ class GitHub::SQLTest < Minitest::Test
     refute_includes sql.query, "foo"
   end
 
-  def test_transaction
+  def test_class_transaction
     GitHub::SQL.run("CREATE TEMPORARY TABLE affected_rows_test (x INT)")
 
     begin
@@ -156,7 +156,7 @@ class GitHub::SQLTest < Minitest::Test
         GitHub::SQL.run("INSERT INTO affected_rows_test VALUES (3), (4)")
         raise "BOOM"
       end
-    rescue => e
+    rescue
       assert_equal 0, GitHub::SQL.new("Select count(*) from affected_rows_test").value
     else
       fail
@@ -167,6 +167,69 @@ class GitHub::SQLTest < Minitest::Test
       GitHub::SQL.run("INSERT INTO affected_rows_test VALUES (3), (4)")
     end
     assert_equal 4, GitHub::SQL.new("Select count(*) from affected_rows_test").value
+  ensure
+    GitHub::SQL.run("DROP TABLE affected_rows_test")
+  end
+
+  def test_class_transaction_works_with_options
+    GitHub::SQL.run("CREATE TEMPORARY TABLE affected_rows_test (x INT)")
+
+    begin
+      GitHub::SQL.transaction(requires_new: true) do
+        GitHub::SQL.run("INSERT INTO affected_rows_test VALUES (1), (2)")
+        GitHub::SQL.run("INSERT INTO affected_rows_test VALUES (3), (4)")
+        raise "BOOM"
+      end
+    rescue
+      assert_equal 0, GitHub::SQL.new("Select count(*) from affected_rows_test").value
+    else
+      fail
+    end
+  ensure
+    GitHub::SQL.run("DROP TABLE affected_rows_test")
+  end
+
+  def test_transaction
+    GitHub::SQL.run("CREATE TEMPORARY TABLE affected_rows_test (x INT)")
+
+    begin
+      sql = GitHub::SQL.new
+      sql.transaction do
+        GitHub::SQL.run("INSERT INTO affected_rows_test VALUES (1), (2)")
+        GitHub::SQL.run("INSERT INTO affected_rows_test VALUES (3), (4)")
+        raise "BOOM"
+      end
+    rescue
+      assert_equal 0, GitHub::SQL.new("Select count(*) from affected_rows_test").value
+    else
+      fail
+    end
+
+    sql = GitHub::SQL.new
+    sql.transaction do
+      GitHub::SQL.run("INSERT INTO affected_rows_test VALUES (1), (2)")
+      GitHub::SQL.run("INSERT INTO affected_rows_test VALUES (3), (4)")
+    end
+    assert_equal 4, GitHub::SQL.new("Select count(*) from affected_rows_test").value
+  ensure
+    GitHub::SQL.run("DROP TABLE affected_rows_test")
+  end
+
+  def test_transaction_works_with_options
+    GitHub::SQL.run("CREATE TEMPORARY TABLE affected_rows_test (x INT)")
+
+    begin
+      sql = GitHub::SQL.new
+      sql.transaction(requires_new: true) do
+        GitHub::SQL.run("INSERT INTO affected_rows_test VALUES (1), (2)")
+        GitHub::SQL.run("INSERT INTO affected_rows_test VALUES (3), (4)")
+        raise "BOOM"
+      end
+    rescue
+      assert_equal 0, GitHub::SQL.new("Select count(*) from affected_rows_test").value
+    else
+      fail
+    end
   ensure
     GitHub::SQL.run("DROP TABLE affected_rows_test")
   end


### PR DESCRIPTION
This PR:

* allows passing methods to class `transaction` method similar to how rails does. Also documents the downside of class transaction method.
* adds instance transaction method for GitHub::SQL descendants that override connection. 
* moves errors, literal and rows to their own file for safe keeping.
* re-orders some methods based on their use. Higher level methods towards the top of the file and building blocks toward the bottom. Helps show priority a bit and puts more likely to change methods or those that you would want to understand and use toward the top. 