### PR TITLE
Add convenient conn_block default

### DIFF
--- a/lib/github/kv.rb
+++ b/lib/github/kv.rb
@@ -49,15 +49,17 @@ module GitHub
     ValueLengthError = Class.new(StandardError)
     UnavailableError = Class.new(StandardError)
 
-    class MissingConnectionError < StandardError; end
-
     def initialize(encapsulated_errors = [SystemCallError], &conn_block)
       @encapsulated_errors = encapsulated_errors
-      @conn_block = conn_block
+      @conn_block = conn_block || default_conn_block
     end
 
     def connection
-      @conn_block.try(:call) || (raise MissingConnectionError, "KV must be initialized with a block that returns a connection")
+      @conn_block.try(:call)
+    end
+
+    def default_conn_block
+      Proc.new { ActiveRecord::Base.connection }
     end
 
     # get :: String -> Result<String | nil>

--- a/test/github/kv_test.rb
+++ b/test/github/kv_test.rb
@@ -6,11 +6,12 @@ class GitHub::KVTest < Minitest::Test
     @kv = GitHub::KV.new { ActiveRecord::Base.connection }
   end
 
-  def test_initialize_without_connection
-    kv = GitHub::KV.new
-    assert_raises GitHub::KV::MissingConnectionError do
-      kv.get("foo").value!
-    end
+  def test_default_connection_block
+    called = false
+    p = Proc.new { called = true }
+    GitHub::KV.any_instance.stubs(:default_conn_block).returns(p)
+    GitHub::KV.new.connection
+    assert(called)
   end
 
   def test_get_and_set


### PR DESCRIPTION
Hi There,

First of all, thanks for the gem!

Since many usages of `Github::KV` have it using the current ActiveRecord connection I added a default block in case none is passed to the constructor

Cheers