### PR TITLE
Add docker-compose file for ease of local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,9 @@ KV supports expiring keys and obeys expiration when performing operations, but d
 
 ## Development
 
-After checking out the repo, run `script/bootstrap` to install dependencies. Then, run `script/test` to run the tests. You can also run `script/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `script/bootstrap` to install dependencies.
+You will need a MySQL database with no password set for the root user, since the tests expect it. Running `docker-compose up` will boot just that.
+Then, run `script/test` to run the tests. You can also run `script/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `script/install`. To release a new version, update the version number in `version.rb`, commit, and then run `script/release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/README.md
+++ b/README.md
@@ -189,9 +189,9 @@ KV supports expiring keys and obeys expiration when performing operations, but d
 
 ## Development
 
-After checking out the repo, run `script/bootstrap` to install dependencies.
-You will need a MySQL database with no password set for the root user, since the tests expect it. Running `docker-compose up` will boot just that.
-Then, run `script/test` to run the tests. You can also run `script/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `script/bootstrap` to install dependencies. Then, run `script/test` to run the tests. You can also run `script/console` for an interactive prompt that will allow you to experiment.
+
+**Note**: You will need a MySQL database with no password set for the root user for the tests. Running `docker-compose up` will boot just that. This functionality is not currently used by GitHub and was from a contributor, so please let us know if it does not work or gets out of date (pull request is best, but an issue will do).
 
 To install this gem onto your local machine, run `script/install`. To release a new version, update the version number in `version.rb`, commit, and then run `script/release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  mysql:
+    image: mysql:5.6
+    environment:
+      - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+    ports:
+      - "3306:3306"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,13 +9,17 @@ require "timecop"
 require "minitest/autorun"
 require "mocha/mini_test"
 
-attempts = 0
-begin
+def connect(opts={})
   ActiveRecord::Base.establish_connection({
     adapter: "mysql2",
     username: "root",
-    database: "github_ds_test",
-  })
+    host: "127.0.0.1",
+  }.merge(opts))
+end
+
+attempts = 0
+begin
+  connect(database: "github_ds_test")
   ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS `key_values`")
 
   # remove db tree if present so we can start fresh
@@ -33,10 +37,7 @@ begin
   CreateKeyValuesTable.up
 rescue
   raise if attempts >= 1
-  ActiveRecord::Base.establish_connection({
-    adapter: "mysql2",
-    username: "root",
-  })
+  connect
   ActiveRecord::Base.connection.execute("CREATE DATABASE IF NOT EXISTS `github_ds_test`")
   attempts += 1
   retry

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,7 +9,7 @@ require "timecop"
 require "minitest/autorun"
 require "mocha/mini_test"
 
-def connect(opts={})
+def active_record_establish_connection(opts = {})
   ActiveRecord::Base.establish_connection({
     adapter: "mysql2",
     username: "root",
@@ -19,7 +19,7 @@ end
 
 attempts = 0
 begin
-  connect(database: "github_ds_test")
+  active_record_establish_connection database: "github_ds_test"
   ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS `key_values`")
 
   # remove db tree if present so we can start fresh
@@ -37,7 +37,7 @@ begin
   CreateKeyValuesTable.up
 rescue
   raise if attempts >= 1
-  connect
+  active_record_establish_connection
   ActiveRecord::Base.connection.execute("CREATE DATABASE IF NOT EXISTS `github_ds_test`")
   attempts += 1
   retry


### PR DESCRIPTION
When making sure I didn't break anything on https://github.com/github/github-ds/pull/33, I had a bit of a hard time running the tests locally, so I added  a `docker-compose.yml` file to ease it up a bit.
It has the minor drawback of having to use a TCP connection to connect to MySQL, but I don't think it matters much for a test env