### PR TITLE
Make test_affected_rows_even_when_query_generates_warning less brittle

### DIFF
--- a/test/github/sql_test.rb
+++ b/test/github/sql_test.rb
@@ -266,10 +266,10 @@ class GitHub::SQLTest < Minitest::Test
     begin
       GitHub::SQL.run("CREATE TEMPORARY TABLE affected_rows_test (x INT)")
       GitHub::SQL.run("INSERT INTO affected_rows_test VALUES (1), (2), (3), (4)")
-      sql = GitHub::SQL.new("UPDATE affected_rows_test SET x = x + 1 WHERE 1 = '1x'")
-      sql.run
 
+      sql = GitHub::SQL.run("UPDATE IGNORE affected_rows_test SET x = x + 1 WHERE 1 = '1x'")
       assert_equal 4, sql.affected_rows
+      assert_equal 1, ActiveRecord::Base.connection.raw_connection.warning_count
     ensure
       GitHub::SQL.run("DROP TABLE affected_rows_test")
     end


### PR DESCRIPTION
I started seeing failures locally for this test because locally I have STRICT_ALL_TABLES in my sql_mode.

Error:

```
$ script/test

bundle exec rake
+ bundle exec rake
      create  db/migrate/20180302154356_create_key_values_table.rb
Run options: --seed 21062

# Running:

................E

Error:
GitHub::SQLTest#test_affected_rows_even_when_query_generates_warning:
ActiveRecord::StatementInvalid: Mysql2::Error: Truncated incorrect DOUBLE value: '1x': UPDATE affected_rows_test SET x = x + 1 WHERE 1 = '1x'
```

The issue was that `1x` gets coerced to `1` when not in strict mode, but raises an error when in strict mode. According to my sql_mode for the session in tests strict was on:

```
p GitHub::SQL.results("SHOW VARIABLES LIKE 'sql_mode'")
# => [["sql_mode", "NO_AUTO_VALUE_ON_ZERO,STRICT_ALL_TABLES,NO_ENGINE_SUBSTITUTION"]]
```

I first went down the path of tweaking the sql_mode for the session, but after reading the docs I realized that there would be less machinery required to just use `IGNORE`.

From https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sql-mode-strict:

> With IGNORE | Warning | Warning (same as without IGNORE or strict SQL mode)

I also added a test to assert that the statement generates a warning since it seems good to know that the testing of a warning is actually creating a warning.