### PR TITLE
Add ttl command to return time of expiry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 gemspec
 
 DEFAULT_RAILS_VERSION = '5.0.2'
+gem "mysql2"
 gem "rails", "~> #{ENV['RAILS_VERSION'] || DEFAULT_RAILS_VERSION}"
 gem "activerecord", "~> #{ENV['RAILS_VERSION'] || DEFAULT_RAILS_VERSION}"

--- a/lib/github/kv.rb
+++ b/lib/github/kv.rb
@@ -286,11 +286,10 @@ module GitHub
       validate_key(key)
 
       Result.new {
-        kvs = GitHub::SQL.results(<<-SQL, :keys => [key], :connection => connection).to_h
-          SELECT `key`, expires_at FROM key_values WHERE `key` IN :keys AND (`expires_at` IS NULL OR `expires_at` > NOW())
+        GitHub::SQL.value(<<-SQL, :key => key, :connection => connection)
+          SELECT expires_at FROM key_values
+          WHERE `key` = :key AND (expires_at IS NULL OR expires_at > NOW())
         SQL
-
-        kvs[key]
       }
     end
 

--- a/test/generators/github/store/active_record_generator_test.rb
+++ b/test/generators/github/store/active_record_generator_test.rb
@@ -4,6 +4,7 @@ require "rails/test_help"
 require "active_record"
 require "rails/generators/test_case"
 require "generators/github/ds/active_record_generator"
+require "mysql2"
 
 class GithubDSActiveRecordGeneratorTest < Rails::Generators::TestCase
   tests Github::Ds::Generators::ActiveRecordGenerator

--- a/test/github/kv_test.rb
+++ b/test/github/kv_test.rb
@@ -177,6 +177,16 @@ class GitHub::KVTest < Minitest::Test
     assert_equal expires, @kv.ttl("foo-ttl").value!
   end
 
+  def test_ttl_for_key_that_exists_but_is_expired
+    @kv.set("foo-ttl", "bar", expires: 1.hour.ago)
+
+    row_count = GitHub::SQL.value <<-SQL, key: "foo-ttl"
+      SELECT count(*) FROM key_values WHERE `key` = :key
+    SQL
+    assert_equal 1, row_count
+    assert_nil @kv.ttl("foo-ttl").value!
+  end
+
   def test_type_checks_key
     assert_raises TypeError do
       @kv.get(0)

--- a/test/github/kv_test.rb
+++ b/test/github/kv_test.rb
@@ -166,6 +166,15 @@ class GitHub::KVTest < Minitest::Test
     assert_equal "bar2", @kv.get("foo").value!
   end
 
+  def test_ttl
+    assert_nil @kv.ttl("foo-ttl")
+
+    expires = 1.hour.from_now
+    @kv.set("foo-ttl", "bar", expires: expires)
+
+    assert_equal expires, @kv.ttl("foo-ttl").value!
+  end
+
   def test_type_checks_key
     assert_raises TypeError do
       @kv.get(0)

--- a/test/github/kv_test.rb
+++ b/test/github/kv_test.rb
@@ -169,7 +169,9 @@ class GitHub::KVTest < Minitest::Test
   def test_ttl
     assert_nil @kv.ttl("foo-ttl").value!
 
-    expires = 1.hour.from_now
+    # the Time.at dance is necessary because MySQL does not support sub-second
+    # precision in DATETIME values
+    expires = Time.at(1.hour.from_now.to_i).utc
     @kv.set("foo-ttl", "bar", expires: expires)
 
     assert_equal expires, @kv.ttl("foo-ttl").value!

--- a/test/github/kv_test.rb
+++ b/test/github/kv_test.rb
@@ -167,7 +167,7 @@ class GitHub::KVTest < Minitest::Test
   end
 
   def test_ttl
-    assert_nil @kv.ttl("foo-ttl")
+    assert_nil @kv.ttl("foo-ttl").value!
 
     expires = 1.hour.from_now
     @kv.set("foo-ttl", "bar", expires: expires)


### PR DESCRIPTION
I recently needed an equivalent of the Redis `ttl` command in `GitHub::KV` and thought I'd open a PR here too in case we want to integrate it into `github-ds` instead of putting it in `lib/github/ds_extensions.rb`.