### PR TITLE
Don't de-dup values in results array

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,11 @@ source "https://rubygems.org"
 gemspec
 
 DEFAULT_RAILS_VERSION = '5.0.2'
-gem "mysql2"
+
+if ENV['RAILS_VERSION'] = '4.2.10'
+  gem 'mysql2', '~> 0.3.18'
+else
+  gem "mysql2"
+end
 gem "rails", "~> #{ENV['RAILS_VERSION'] || DEFAULT_RAILS_VERSION}"
 gem "activerecord", "~> #{ENV['RAILS_VERSION'] || DEFAULT_RAILS_VERSION}"

--- a/test/github/sql_test.rb
+++ b/test/github/sql_test.rb
@@ -359,4 +359,31 @@ class GitHub::SQLModelTest < Minitest::Test
       ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS `repositories`")
     end
   end
+
+  def test_results_return_all_values_and_hash_returns_deduplicated_values
+    begin
+      ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS `repositories`")
+      ActiveRecord::Base.connection.execute <<-SQL
+        CREATE TABLE `repositories` (
+          `id` int(11) NOT NULL AUTO_INCREMENT,
+          `name` varchar(255) DEFAULT NULL,
+          `updated_at` datetime DEFAULT NULL,
+          `created_at` datetime DEFAULT NULL,
+          PRIMARY KEY (`id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+      SQL
+      Repository.create(name: "I am a repo")
+
+      sql = GitHub::SQL.new(repo_id: 1)
+
+      sql.add("SELECT id, NULL, NULL, name from repositories")
+
+      assert_equal [1, nil, nil, "I am a repo"], sql.results.flatten
+
+      # Hashes can't have more than one key with the same name, so `to_ary` will de-dup the NULL column values
+      assert_equal [{ "id" => 1, "NULL" => nil, "name" => "I am a repo" }], sql.hash_results
+    ensure
+      ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS `repositories`")
+    end
+  end
 end


### PR DESCRIPTION
Problem:

If a user passed duplicate column names to GitHub::DS, for example
`sql.add(SELECT id, NULL, NULL, name from repositories)` the valued
returned by `result` wouldn't line up with the column names. Instead
what would be returned is:

```
sql.results
[[1, nil, "repo name"], [2, nil, "repo name 2"]]
```

instead of the correct value set:

```
sql.results
[[1, nil, nil, "repo name"], [2, nil, nil, "repo name 2"]]
```

This is because we were calling `to_ary` on the
`ActiveRecord::Base#result`. This would loop through the columns and
rows and pair them up into a hash. The underlying problem is hashes
cannot contain keys with the same value, and Ruby will de-dup the keys
before retunring the result.

Solution: 
To fix this problem we can instead call `rows` on the returned results
which will give us all the rows. If we want `hash_results` instead we
can accept that a hash de-dups the values since we likely will never
turn a hash back into a SQL statement.

Originally I considered raising if there were duplicate columns passed
in but after some investigation into Rails I found that Rails is able to
take `["title", "title"]` as the columns and then apply those columns
properly to the joined tables, so that wasn't a viable solution.

After considering the options it makes sense for results to return ALL
the results and for the hash to return just the de-duplicated keys. This
is the behavior in Rails for many years so this behavior seems correct.

cc/ @rhettg @spraints @jdennes 