### PR TITLE
Rails 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.5
 script: bundle exec rake
 env:
+  - RAILS_VERSION=5.2.0
   - RAILS_VERSION=5.1.5
   - RAILS_VERSION=5.0.6
   - RAILS_VERSION=4.2.10

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,5 @@ source "https://rubygems.org"
 gemspec
 
 DEFAULT_RAILS_VERSION = '5.0.2'
-gem "mysql2"
 gem "rails", "~> #{ENV['RAILS_VERSION'] || DEFAULT_RAILS_VERSION}"
 gem "activerecord", "~> #{ENV['RAILS_VERSION'] || DEFAULT_RAILS_VERSION}"

--- a/test/generators/github/store/active_record_generator_test.rb
+++ b/test/generators/github/store/active_record_generator_test.rb
@@ -4,7 +4,6 @@ require "rails/test_help"
 require "active_record"
 require "rails/generators/test_case"
 require "generators/github/ds/active_record_generator"
-require "mysql2"
 
 class GithubDSActiveRecordGeneratorTest < Rails::Generators::TestCase
   tests Github::Ds::Generators::ActiveRecordGenerator


### PR DESCRIPTION
Rails 5.2 tis released. Let us test it going forward. 

This PR adds rails 5.2 to the travis build. The only oddity is that 5.2 returns TRUE and FALSE instead of 1 and 0 like previous versions (unless I'm missing something which I would be A OK with). 