### PR TITLE
Allow sanitization of nil values in GitHub::SQL

### DIFF
--- a/lib/github/sql.rb
+++ b/lib/github/sql.rb
@@ -393,6 +393,9 @@ module GitHub
       when Symbol
         connection.quote value.to_s
 
+      when nil
+        GitHub::SQL::NULL.value
+
       else
         raise BadValue, value
       end

--- a/test/github/sql_test.rb
+++ b/test/github/sql_test.rb
@@ -20,14 +20,13 @@ class GitHub::SQLTest < Minitest::Test
       [foo,                  "foo"],
       [[1, 2],               "(1, 2)"],
       [rows,                 "(1, 2), (3, 4)"], # bulk inserts
+      [nil,                  "NULL"],
     ]
 
     BAD_VALUE_TESTS = [
       Hash.new,
-      nil,
       [],
-      [1, 2, nil],
-      [[1], [nil]],
+      [[1]],
       [[1, 2], [3, 4]]
     ]
   end


### PR DESCRIPTION
Using `nil` as a value in GitHub::SQL queries raises `GitHub::SQL::BadValue: Can't sanitize a NilClass: nil` even though `nil` has a well-defined counterpart in SQL as `NULL`

This PR changes incoming `nil` values to `GitHub::SQL::NULL.value` during sanitization rather than calling it a bad value.

Looking at the sanitize logic, it seems that the method was written before `GitHub::SQL::NULL` was added.   Was allowing `nil` in this scenario just missed?  Or was it an intentional decision to disallow `nil` input values?