### PR TITLE
Fix binary encoding and bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.2
   - 2.3
   - 2.4
   - 2.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.5
 script: bundle exec rake
 env:
+  - RAILS_VERSION=6.0.0.rc1
   - RAILS_VERSION=5.2.0
   - RAILS_VERSION=5.1.5
   - RAILS_VERSION=5.0.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: ruby
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '<2'
 rvm:
   - 2.3
   - 2.4

--- a/github-ds.gemspec
+++ b/github-ds.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">= 3.2", "< 6.0"
+  spec.add_dependency "activerecord", ">= 3.2"
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/github-ds.gemspec
+++ b/github-ds.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activerecord", ">= 3.2"
 
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "bundler", ">= 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "timecop", "~> 0.8.1"

--- a/lib/github/kv.rb
+++ b/lib/github/kv.rb
@@ -136,7 +136,7 @@ module GitHub
       validate_expires(expires) if expires
 
       rows = kvs.map { |key, value|
-        [key, value, GitHub::SQL::NOW, GitHub::SQL::NOW, expires || GitHub::SQL::NULL]
+        [key, GitHub::SQL::BINARY(value), GitHub::SQL::NOW, GitHub::SQL::NOW, expires || GitHub::SQL::NULL]
       }
 
       encapsulate_error do
@@ -225,7 +225,7 @@ module GitHub
           DELETE FROM key_values WHERE `key` = :key AND expires_at <= NOW()
         SQL
 
-        sql = GitHub::SQL.run(<<-SQL, :key => key, :value => value, :expires => expires || GitHub::SQL::NULL, :connection => connection)
+        sql = GitHub::SQL.run(<<-SQL, :key => key, :value => GitHub::SQL::BINARY(value), :expires => expires || GitHub::SQL::NULL, :connection => connection)
           INSERT IGNORE INTO key_values (`key`, value, created_at, updated_at, expires_at)
           VALUES (:key, :value, NOW(), NOW(), :expires)
         SQL

--- a/lib/github/kv.rb
+++ b/lib/github/kv.rb
@@ -136,7 +136,8 @@ module GitHub
       validate_expires(expires) if expires
 
       rows = kvs.map { |key, value|
-        [key, GitHub::SQL::BINARY(value), GitHub::SQL::NOW, GitHub::SQL::NOW, expires || GitHub::SQL::NULL]
+        value = value.is_a?(GitHub::SQL::Literal) ? value : GitHub::SQL::BINARY(value)
+        [key, value, GitHub::SQL::NOW, GitHub::SQL::NOW, expires || GitHub::SQL::NULL]
       }
 
       encapsulate_error do
@@ -225,7 +226,8 @@ module GitHub
           DELETE FROM key_values WHERE `key` = :key AND expires_at <= NOW()
         SQL
 
-        sql = GitHub::SQL.run(<<-SQL, :key => key, :value => GitHub::SQL::BINARY(value), :expires => expires || GitHub::SQL::NULL, :connection => connection)
+        value = value.is_a?(GitHub::SQL::Literal) ? value : GitHub::SQL::BINARY(value)
+        sql = GitHub::SQL.run(<<-SQL, :key => key, :value => value, :expires => expires || GitHub::SQL::NULL, :connection => connection)
           INSERT IGNORE INTO key_values (`key`, value, created_at, updated_at, expires_at)
           VALUES (:key, :value, NOW(), NOW(), :expires)
         SQL

--- a/test/github/kv_test.rb
+++ b/test/github/kv_test.rb
@@ -21,7 +21,7 @@ class GitHub::KVTest < Minitest::Test
     assert_equal "bar", @kv.get("foo").value!
   end
 
-  def test_get_set_binary_data
+  def test_get_set_literal
     assert_nil @kv.get("foo").value!
 
     @kv.set("foo", GitHub::SQL::BINARY("bar"))


### PR DESCRIPTION
This PR takes #42 and fixes the builds by uninstalling bundler 2 and installing a bundler less than 2. Bundler 2 doesn't support older versions of Ruby we need to test so we need to use the older one.

cc/ @dbussink @zerowidth 