### PR TITLE
kv: Pass current time into queries

### DIFF
--- a/lib/github/kv.rb
+++ b/lib/github/kv.rb
@@ -51,8 +51,24 @@ module GitHub
 
     class MissingConnectionError < StandardError; end
 
-    def initialize(encapsulated_errors = [SystemCallError], &conn_block)
+    attr_accessor :use_local_time
+
+    # initialize :: [Exception], Boolean, Proc -> nil
+    #
+    # Initialize a new KV instance.
+    #
+    # encapsulated_errors - An Array of Exception subclasses that, when raised,
+    #                       will be replaced with UnavailableError.
+    # use_local_time:     - Whether to use Ruby's `Time.now` instaed of MySQL's
+    #                       `NOW()` function. This is mostly useful in testing
+    #                       where time needs to be modified (eg. Timecop).
+    #                       Default false.
+    # &conn_block         - A block to call to open a new database connection.
+    #
+    # Returns nothing.
+    def initialize(encapsulated_errors = [SystemCallError], use_local_time: false, &conn_block)
       @encapsulated_errors = encapsulated_errors
+      @use_local_time = use_local_time
       @conn_block = conn_block
     end
 
@@ -93,7 +109,7 @@ module GitHub
       validate_key_array(keys)
 
       Result.new {
-        kvs = GitHub::SQL.results(<<-SQL, :keys => keys, :now => Time.now, :connection => connection).to_h
+        kvs = GitHub::SQL.results(<<-SQL, :keys => keys, :now => now, :connection => connection).to_h
           SELECT `key`, value FROM key_values WHERE `key` IN :keys AND (`expires_at` IS NULL OR `expires_at` > :now)
         SQL
 
@@ -137,7 +153,7 @@ module GitHub
 
       rows = kvs.map { |key, value|
         value = value.is_a?(GitHub::SQL::Literal) ? value : GitHub::SQL::BINARY(value)
-        [key, value, Time.now, Time.now, expires || GitHub::SQL::NULL]
+        [key, value, now, now, expires || GitHub::SQL::NULL]
       }
 
       encapsulate_error do
@@ -186,7 +202,7 @@ module GitHub
       validate_key_array(keys)
 
       Result.new {
-        existing_keys = GitHub::SQL.values(<<-SQL, :keys => keys, :now => Time.now, :connection => connection).to_set
+        existing_keys = GitHub::SQL.values(<<-SQL, :keys => keys, :now => now, :connection => connection).to_set
           SELECT `key` FROM key_values WHERE `key` IN :keys AND (`expires_at` IS NULL OR `expires_at` > :now)
         SQL
 
@@ -222,12 +238,12 @@ module GitHub
         # achieve the same thing with the right INSERT ... ON DUPLICATE KEY UPDATE
         # query, but then we would not be able to rely on affected_rows
 
-        GitHub::SQL.run(<<-SQL, :key => key, :now => Time.now, :connection => connection)
+        GitHub::SQL.run(<<-SQL, :key => key, :now => now, :connection => connection)
           DELETE FROM key_values WHERE `key` = :key AND expires_at <= :now
         SQL
 
         value = value.is_a?(GitHub::SQL::Literal) ? value : GitHub::SQL::BINARY(value)
-        sql = GitHub::SQL.run(<<-SQL, :key => key, :value => value, :now => Time.now, :expires => expires || GitHub::SQL::NULL, :connection => connection)
+        sql = GitHub::SQL.run(<<-SQL, :key => key, :value => value, :now => now, :expires => expires || GitHub::SQL::NULL, :connection => connection)
           INSERT IGNORE INTO key_values (`key`, value, created_at, updated_at, expires_at)
           VALUES (:key, :value, :now, :now, :expires)
         SQL
@@ -288,7 +304,7 @@ module GitHub
       validate_key(key)
 
       Result.new {
-        GitHub::SQL.value(<<-SQL, :key => key, :now => Time.now, :connection => connection)
+        GitHub::SQL.value(<<-SQL, :key => key, :now => now, :connection => connection)
           SELECT expires_at FROM key_values
           WHERE `key` = :key AND (expires_at IS NULL OR expires_at > :now)
         SQL
@@ -296,6 +312,10 @@ module GitHub
     end
 
   private
+    def now
+      use_local_time ? Time.now : GitHub::SQL::NOW
+    end
+
     def validate_key(key, error_message: nil)
       unless key.is_a?(String)
         raise TypeError, error_message || "key must be a String in #{self.class.name}, but was #{key.class}"

--- a/test/github/kv_test.rb
+++ b/test/github/kv_test.rb
@@ -216,29 +216,39 @@ class GitHub::KVTest < Minitest::Test
   end
 
   def test_timecop
-    Timecop.freeze(1.month.ago) do
-      # setnx - currently unset
-      @kv.setnx("foo", "asdf", expires: 1.day.from_now.utc)
-      assert_equal "asdf", @kv.get("foo").value!
+    with_local_time do
+      Timecop.freeze(1.month.ago) do
+        # setnx - currently unset
+        @kv.setnx("foo", "asdf", expires: 1.day.from_now.utc)
+        assert_equal "asdf", @kv.get("foo").value!
 
-      # setnx - currently expired
-      @kv.set("foo", "bar", expires: 1.day.ago.utc)
-      @kv.setnx("foo", "asdf", expires: 1.day.from_now.utc)
-      assert_equal "asdf", @kv.get("foo").value!
+        # setnx - currently expired
+        @kv.set("foo", "bar", expires: 1.day.ago.utc)
+        @kv.setnx("foo", "asdf", expires: 1.day.from_now.utc)
+        assert_equal "asdf", @kv.get("foo").value!
 
-      # set/get
-      @kv.set("foo", "bar", expires: 1.day.from_now.utc)
-      assert_equal "bar", @kv.get("foo").value!
+        # set/get
+        @kv.set("foo", "bar", expires: 1.day.from_now.utc)
+        assert_equal "bar", @kv.get("foo").value!
 
-      # exists
-      assert_equal true, @kv.exists("foo").value!
+        # exists
+        assert_equal true, @kv.exists("foo").value!
 
-      # ttl
-      assert_equal 1.day.from_now.to_i, @kv.ttl("foo").value!.to_i
+        # ttl
+        assert_equal 1.day.from_now.to_i, @kv.ttl("foo").value!.to_i
 
-      # mset/mget
-      @kv.mset({"foo" => "baz"}, expires: 1.day.from_now.utc)
-      assert_equal ["baz"], @kv.mget(["foo"]).value!
+        # mset/mget
+        @kv.mset({"foo" => "baz"}, expires: 1.day.from_now.utc)
+        assert_equal ["baz"], @kv.mget(["foo"]).value!
+      end
     end
+  end
+
+  def with_local_time(&blk)
+    use_local_time_was = @kv.use_local_time
+    @kv.use_local_time = true
+    blk.call
+  ensure
+    @kv.use_local_time = use_local_time_was
   end
 end


### PR DESCRIPTION
KV seems not to work well with timecop. For example

```ruby
now = Time.at(1556212894)

Timecop.freeze(now) do
  GitHub.kv.set("foo", "bar", expires: now + 1.day)
  GitHub.kv.get("foo")
  #=> <GitHub::Result value: nil>
end
```

In this example, a KV value is set with an expiration in the past. When we try to look it up, the query is comparing the expiration to MySQL's `NOW()` function, which won't respect the time being frozen by Timecop.

This PR tries to solve this by passing in Ruby's `Time.now` to queries instead of relying on MySQL's `NOW()` function.