### PR TITLE
Prevent queries that are meaningless from running

### DIFF
--- a/lib/github/sql.rb
+++ b/lib/github/sql.rb
@@ -38,6 +38,7 @@ module GitHub
   #   GitHub::SQL::ROWS(array_of_arrays).
   #
   class SQL
+    COMMENT_REGEX = %r{(?:\s*--.*|/\*(?:[^\*]|\*[^/])*\*/)}m
     # Public: Run inside a transaction. Class version of this method only works
     # if only one connection is in use. If passing connections to
     # GitHub::SQL#initialize or overriding connection then you'll need to use
@@ -242,6 +243,8 @@ module GitHub
           ar_results = connection.select_all(query, "#{self.class.name} Select")
           @hash_results = ar_results.to_ary
           @results = ar_results.rows
+        when /\A(#{COMMENT_REGEX})?\Z/
+          raise Error, "#{query.inspect} has no meaningful contents"
         else
           @results = connection.execute(query, "#{self.class.name} Execute").to_a
         end

--- a/test/github/sql_test.rb
+++ b/test/github/sql_test.rb
@@ -161,6 +161,42 @@ class GitHub::SQLTest < Minitest::Test
     refute_includes sql.query, "foo"
   end
 
+  def test_block_comment_alone_raise
+    query = "  /* test */"
+    assert_raises GitHub::SQL::Error, "#{query.inspect} has no meaningful contents" do
+      GitHub::SQL.new(query).results
+    end
+  end
+
+  def test_comment_alone_raise
+    query = "  -- test"
+    assert_raises GitHub::SQL::Error, "#{query.inspect} has no meaningful contents" do
+      GitHub::SQL.new(query).results
+    end
+  end
+
+  def test_empty_query_raise
+    query = ""
+    assert_raises GitHub::SQL::Error, "#{query.inspect} has no meaningful contents" do
+      GitHub::SQL.new(query).results
+    end
+  end
+
+  def test_empty_string_query_raise
+    query = "  "
+    assert_raises GitHub::SQL::Error, "#{query.inspect} has no meaningful contents" do
+      GitHub::SQL.new(query).results
+    end
+  end
+
+  def test_queries_with_block_comments_do_not_raise
+    assert_equal [[1]], GitHub::SQL.new("(SELECT(1)) /* hi */").results
+  end
+
+  def test_queries_with_comments_do_not_raise
+    assert_equal [[1]], GitHub::SQL.new("(SELECT(1)) -- hi").results
+  end
+
   def test_class_transaction
     GitHub::SQL.run("CREATE TEMPORARY TABLE affected_rows_test (x INT)")
 


### PR DESCRIPTION
Queries that are only empty strings or comments will now raise
rather then running and returning nothing.