### PR TITLE
Fix auth rate limiter unable to increment problem due to expired kv entry still around (duplicate key) by updating expired_at field for those entries

### DIFF
--- a/lib/github/kv.rb
+++ b/lib/github/kv.rb
@@ -328,7 +328,7 @@ module GitHub
             `expires_at`=IF(
               concat('',`value`*1) = `value`,
               IF(
-                :touch,
+                :touch OR (`expires_at` IS NULL OR `expires_at`<:now),
                 :expires,
                 `expires_at`
               ),


### PR DESCRIPTION
Fixes https://github.com/github/business-support/issues/3310 

This PR updates the `lib/github/kv.rb` file, adding additional condition so that when we encounter a duplicated key entry while incrementing KV for auth rate limiter, we will check if the old kv entry has expired or not, if it has, we will update its expires_at field with the new expiration value provided. 

This is to fix the issue with `short_login` and `long_login` where after the previous kv entry expires, the subsequent kv increment call from auth rate limiter won't update the kv due to it being a duplicate key - the previous expired kv entry is not removed fast enough in enterprise - as opposed to in dotcom there is a job that removes expired kv entries every few minutes). Thus causing rate limit for auth in enterprise to only limit it once and not again till a higher counter is reached or till the entry is removed by job. 

Note: we plan to write a test inside dotcom code `github/test/models/authentication_limit_test.rb` to test this change to make sure it fixes the problem.


/cc @github/prodsec 