### PR TITLE
Add a touch operation

### DIFF
--- a/lib/github/kv.rb
+++ b/lib/github/kv.rb
@@ -190,6 +190,7 @@ module GitHub
     #
     # Touches the specified key updating or clearing the expiry time without changing the value.
     # Does not create the key if it does not already exist.
+    # Will keep the existing timestamp if it is greater than expires.
     # Returns nil. Raises on error.
     #
     # Example:
@@ -207,6 +208,7 @@ module GitHub
     #
     # Touches the specified keys, updating or clearing the expiry time without changing the values.
     # Does not create the keys if they do not already exist.
+    # Will keep the existing timestamp if it is greater than expires.
     # Returns nil. Raises on error.
     #
     # Example:
@@ -225,7 +227,7 @@ module GitHub
         GitHub::SQL.run(<<-SQL, :keys => keys, :expires => expires || GitHub::SQL::NULL, :now => now, :connection => connection)
           UPDATE #{@table_name}
           SET updated_at = :now,
-              expires_at = :expires
+              expires_at = GREATEST(IFNULL(expires_at, :expires), :expires)
           WHERE `key` IN :keys
           AND (`expires_at` IS NULL OR `expires_at` > :now)
         SQL

--- a/test/github/kv_test.rb
+++ b/test/github/kv_test.rb
@@ -372,10 +372,27 @@ class GitHub::KVTest < Minitest::Test
     expires = Time.at(1.hour.from_now.to_i).utc
 
     @kv.set("foo-touch", "value", expires: expires)
-    
+
+    refute_nil @kv.ttl("foo-touch").value!
+
     @kv.touch("foo-touch")
 
     assert_nil @kv.ttl("foo-touch").value!
+    assert_equal "value", @kv.get("foo-touch").value!
+  end
+
+  def test_touch_uses_greatest_expiry
+    # the Time.at dance is necessary because MySQL does not support sub-second
+    # precision in DATETIME values
+    expires = Time.at(10.hour.from_now.to_i).utc
+
+    @kv.set("foo-touch", "value", expires: expires)
+
+    refute_nil @kv.ttl("foo-touch").value!
+
+    @kv.touch("foo-touch", expires: Time.at(1.hour.from_now.to_i).utc)
+
+    assert_equal expires, @kv.ttl("foo-touch").value!
     assert_equal "value", @kv.get("foo-touch").value!
   end
 


### PR DESCRIPTION
Stop keys expiring without changing (or knowing) the value. This can be used to build a heartbeat into a long running task without introducing a dirty read, or to extend the length of a key some time after it was written.

I've made so that if you cannot shorten the life of the key. This means that if two competing actors disagree about when a key length should expire, the longest expiry holds.