### PR TITLE
Replace `(to_s#{format.inspect})` with `to_formatted_s(#{format.inspect})` as the former is deprecated for certain format conversions

### DIFF
--- a/lib/github/sql.rb
+++ b/lib/github/sql.rb
@@ -381,7 +381,7 @@ module GitHub
 
       when DateTime, Time, Date
         enforce_timezone do
-          connection.quote value.to_s(:db)
+          connection.quote value.to_formatted_s(:db)
         end
 
       when true

--- a/test/github/sql_test.rb
+++ b/test/github/sql_test.rb
@@ -104,7 +104,7 @@ class GitHub::SQLTest < Minitest::Test
   def test_add_date
     now = Time.now.utc
     sql = GitHub::SQL.new ":now", :now => now
-    assert_equal "'#{now.to_s(:db)}'", sql.query
+    assert_equal "'#{now.to_formatted_s(:db)}'", sql.query
   end
 
   def test_bind


### PR DESCRIPTION
This PR replaces `to_s(#{format.inspect})` with `to_formatted_s(#{format.inspect})`. `to_s` is deprecated in the latest [rails/rails 7.1.0.alpha.e8c0293](https://github.com/rails/rails/blob/a4d685b2842d91cb702259c07c50c2623288c714/activesupport/lib/active_support/core_ext/numeric/deprecated_conversions.rb).

