### PR TITLE
Call .dup on an empty string to get an non-frozen option

### DIFF
--- a/lib/github/sql.rb
+++ b/lib/github/sql.rb
@@ -152,7 +152,7 @@ module GitHub
       @last_insert_id = nil
       @affected_rows  = nil
       @binds          = binds ? binds.dup : {}
-      @query          = ""
+      @query          = "".dup
       @connection     = @binds.delete :connection
       @force_timezone = @binds.delete :force_timezone
 


### PR DESCRIPTION
Frozen string literals might be a default thing in future Ruby versions (https://bugs.ruby-lang.org/issues/20205).

This PR fixes a tiny incompatibility in `sql.rb` where we have one instance of an empty string.