### PR TITLE
[CI only] Explicitly require logger to fix Concurrent-Ruby removing the dependency

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 
 require "pathname"
+require "logger"
 root_path = Pathname(File.expand_path("../..", __FILE__))
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "github/ds"


### PR DESCRIPTION
CI fix for `uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger (NameError)` which happens because newer versions of Concurrent-Ruby removed a dependency on Logger but older versions of Rails aren't compatible with that.