### PR TITLE
Bump Ruby and Rails versions that tests run against

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.0', '3.1', '3.2', '3.3']
-        rails-version: ['6.1.7', '7.0.8', '7.1.3']
+        ruby-version: ['3.2', '3.3', '3.4']
+        rails-version: ['7.1.5', '7.2.2', '8.0.2']
     env:
       RAILS_VERSION: ${{ matrix.rails-version }}
     steps:

--- a/github-ds.gemspec
+++ b/github-ds.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/github/github-ds"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = '>= 3.2'
+  spec.required_ruby_version = ">= 3.2"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.

--- a/github-ds.gemspec
+++ b/github-ds.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/github/github-ds"
   spec.license       = "MIT"
 
+  spec.required_ruby_version = '>= 3.2'
+
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
@@ -30,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">= 3.2"
+  spec.add_dependency "activerecord", ">= 7.1.5"
 
   spec.add_development_dependency "bundler", ">= 1.14"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Ruby 3.0 and 3.1 are EOL. 3.2 is still receiving security updates. https://www.ruby-lang.org/en/downloads/branches/

Rails have a new maintenance policy (https://rubyonrails.org/maintenance) and 7.0 went out of support in April